### PR TITLE
feat: add educational ui helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,5 @@ This repository contains a vanilla JavaScript interactive neural network visuali
 - Keep log entries concise and add them in reverse chronological order (newest at the top).
 
 ## Log
-
-- *Log entries go here.*
+ - 2025-08-12: Added activation function explanations and output prediction text to make the interface more instructional.
+ - *Log entries go here.*

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
                     Show Math
                 </button>
             </div>
+            <p id="activationInfo" class="activation-info"></p>
         </div>
 
         <!-- Input Pattern Editor -->
@@ -97,6 +98,7 @@
             <h3>Network Output</h3>
             <p>The output layer shows the network's final decision. For the default MIM configuration, the two outputs are trained to detect the two diagonal patterns. A value close to 1.0 indicates a strong detection of that pattern.</p>
             <div id="outputResults" class="output-results"></div>
+            <p id="predictionText" class="prediction-text"></p>
             <div class="output-info">
                 <p>In the original MIM: Output 0 = Diagonal &#92;, Output 1 = Diagonal /</p>
                 <p>Values closer to 1.0 indicate stronger detection</p>

--- a/script.js
+++ b/script.js
@@ -44,6 +44,15 @@ class NeuralNetworkBuilder {
         // UI state
         this.activationFunction = 'sigmoid';
         this.showCalculations = false;
+
+        // Educational labels and descriptions
+        this.outputLabels = ['Diagonal \\', 'Diagonal /'];
+        this.activationDescriptions = {
+            sigmoid: 'Sigmoid squashes values between 0 and 1, useful for probabilities.',
+            relu: 'ReLU outputs zero for negatives and the input for positives.',
+            tanh: 'Tanh outputs values between -1 and 1, centered at zero.',
+            linear: 'Linear passes values through unchanged.'
+        };
         
         this.init();
     }
@@ -58,6 +67,7 @@ class NeuralNetworkBuilder {
         this.renderNetwork();
         this.renderWeightMatrices();
         this.renderResults();
+        this.updateActivationInfo();
         
         // Initialize Lucide icons
         if (typeof lucide !== 'undefined') {
@@ -90,6 +100,7 @@ class NeuralNetworkBuilder {
             this.renderNetwork();
             this.renderResults();
             this.renderMathematicalBreakdown();
+            this.updateActivationInfo();
         });
         
         // Pixel grid
@@ -532,34 +543,49 @@ class NeuralNetworkBuilder {
     renderResults() {
         const container = document.getElementById('outputResults');
         container.innerHTML = '';
-        
+
         const outputActivations = this.activations[`${this.layers.length - 1}`] || [];
-        
+
         outputActivations.forEach((output, index) => {
             const item = document.createElement('div');
             item.className = 'output-item';
-            
+
             const label = document.createElement('span');
             label.className = 'output-label';
-            label.textContent = `Output ${index}:`;
-            
+            label.textContent = `${this.outputLabels[index] || 'Output ' + index}:`;
+
             const bar = document.createElement('div');
             bar.className = 'output-bar';
-            
+
             const fill = document.createElement('div');
             fill.className = `output-fill ${output > 0 ? 'positive' : 'negative'}`;
             fill.style.width = `${Math.abs(output) * 100}%`;
-            
+
             const value = document.createElement('span');
             value.className = 'output-value';
             value.textContent = output.toFixed(3);
-            
+
             bar.appendChild(fill);
             item.appendChild(label);
             item.appendChild(bar);
             item.appendChild(value);
             container.appendChild(item);
         });
+
+        const predictionEl = document.getElementById('predictionText');
+        if (predictionEl) {
+            if (outputActivations.length) {
+                const maxVal = Math.max(...outputActivations);
+                const maxIndex = outputActivations.indexOf(maxVal);
+                if (maxVal >= 0.5) {
+                    predictionEl.textContent = `${this.outputLabels[maxIndex] || 'Pattern'} detected (confidence ${maxVal.toFixed(2)})`;
+                } else {
+                    predictionEl.textContent = 'No strong pattern detected';
+                }
+            } else {
+                predictionEl.textContent = '';
+            }
+        }
     }
     
     /**
@@ -678,6 +704,13 @@ class NeuralNetworkBuilder {
             
             container.appendChild(layerDiv);
         });
+    }
+
+    updateActivationInfo() {
+        const info = document.getElementById('activationInfo');
+        if (info) {
+            info.textContent = this.activationDescriptions[this.activationFunction] || '';
+        }
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -266,6 +266,12 @@ body {
     margin-bottom: 12px;
 }
 
+.prediction-text {
+    font-size: 14px;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
 .output-item {
     display: flex;
     align-items: center;
@@ -503,6 +509,12 @@ body {
     color: #6b7280;
     margin-bottom: 12px;
     font-size: 14px;
+}
+
+.activation-info {
+    font-size: 14px;
+    color: #6b7280;
+    margin-top: 8px;
 }
 
 .visualization-section {


### PR DESCRIPTION
## Summary
- show descriptive text for selected activation function
- label outputs with diagonal names and summarize predicted pattern

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aa64889588327b193307e576f1f8f