### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,6 @@ This repository contains a vanilla JavaScript interactive neural network visuali
 - Keep log entries concise and add them in reverse chronological order (newest at the top).
 
 ## Log
+ - 2025-08-13: Added dark mode toggle with persistent theme settings to improve UI/UX.
  - 2025-08-12: Added activation function explanations and output prediction text to make the interface more instructional.
  - *Log entries go here.*

--- a/index.html
+++ b/index.html
@@ -55,6 +55,11 @@
                     <i data-lucide="book-open"></i>
                     Show Math
                 </button>
+
+                <button id="themeToggle" class="btn btn-gray">
+                    <i data-lucide="moon"></i>
+                    Dark Mode
+                </button>
             </div>
             <p id="activationInfo" class="activation-info"></p>
         </div>

--- a/script.js
+++ b/script.js
@@ -53,7 +53,9 @@ class NeuralNetworkBuilder {
             tanh: 'Tanh outputs values between -1 and 1, centered at zero.',
             linear: 'Linear passes values through unchanged.'
         };
-        
+
+        this.isDarkMode = localStorage.getItem('theme') === 'dark';
+
         this.init();
     }
     
@@ -68,7 +70,8 @@ class NeuralNetworkBuilder {
         this.renderWeightMatrices();
         this.renderResults();
         this.updateActivationInfo();
-        
+        this.initTheme();
+
         // Initialize Lucide icons
         if (typeof lucide !== 'undefined') {
             lucide.createIcons();
@@ -92,7 +95,8 @@ class NeuralNetworkBuilder {
         document.getElementById('removeLayerBtn').addEventListener('click', () => this.removeHiddenLayer());
         document.getElementById('resetBtn').addEventListener('click', () => this.resetToMIM());
         document.getElementById('showMathBtn').addEventListener('click', () => this.toggleMath());
-        
+        document.getElementById('themeToggle').addEventListener('click', () => this.toggleTheme());
+
         // Activation function selector
         document.getElementById('activationSelect').addEventListener('change', (e) => {
             this.activationFunction = e.target.value;
@@ -710,6 +714,30 @@ class NeuralNetworkBuilder {
         const info = document.getElementById('activationInfo');
         if (info) {
             info.textContent = this.activationDescriptions[this.activationFunction] || '';
+        }
+    }
+
+    initTheme() {
+        document.body.classList.toggle('dark', this.isDarkMode);
+        this.updateThemeButton();
+    }
+
+    toggleTheme() {
+        this.isDarkMode = !this.isDarkMode;
+        document.body.classList.toggle('dark', this.isDarkMode);
+        localStorage.setItem('theme', this.isDarkMode ? 'dark' : 'light');
+        this.updateThemeButton();
+    }
+
+    updateThemeButton() {
+        const btn = document.getElementById('themeToggle');
+        if (btn) {
+            btn.innerHTML = this.isDarkMode
+                ? '<i data-lucide="sun"></i> Light Mode'
+                : '<i data-lucide="moon"></i> Dark Mode';
+            if (typeof lucide !== 'undefined') {
+                lucide.createIcons();
+            }
         }
     }
 }

--- a/style.css
+++ b/style.css
@@ -5,18 +5,40 @@
     box-sizing: border-box;
 }
 
+:root {
+    --text-color: #374151;
+    --bg-color: #f9fafb;
+    --container-bg-color: #ffffff;
+    --controls-bg-color: #f3f4f6;
+    --input-bg-color: #dbeafe;
+    --network-bg-color: #f9fafb;
+    --heading-color: #1f2937;
+    --muted-text-color: #6b7280;
+}
+
+body.dark {
+    --text-color: #f3f4f6;
+    --bg-color: #1f2937;
+    --container-bg-color: #111827;
+    --controls-bg-color: #374151;
+    --input-bg-color: #1e3a8a;
+    --network-bg-color: #1f2937;
+    --heading-color: #f3f4f6;
+    --muted-text-color: #9ca3af;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.6;
-    color: #374151;
-    background-color: #f9fafb;
+    color: var(--text-color);
+    background-color: var(--bg-color);
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 24px;
-    background-color: white;
+    background-color: var(--container-bg-color);
     min-height: 100vh;
 }
 
@@ -28,12 +50,12 @@ body {
 .header h1 {
     font-size: 2rem;
     font-weight: bold;
-    color: #1f2937;
+    color: var(--heading-color);
     margin-bottom: 8px;
 }
 
 .header p {
-    color: #6b7280;
+    color: var(--muted-text-color);
 }
 
 /* Controls */
@@ -43,7 +65,7 @@ body {
     gap: 16px;
     align-items: center;
     padding: 16px;
-    background-color: #f3f4f6;
+    background-color: var(--controls-bg-color);
     border-radius: 8px;
     margin-bottom: 24px;
 }
@@ -112,7 +134,7 @@ body {
 /* Input Section */
 .input-section {
     padding: 16px;
-    background-color: #dbeafe;
+    background-color: var(--input-bg-color);
     border-radius: 8px;
     margin-bottom: 24px;
 }
@@ -175,7 +197,7 @@ body {
 /* Network Visualization */
 .network-container {
     position: relative;
-    background-color: #f9fafb;
+    background-color: var(--network-bg-color);
     border-radius: 8px;
     padding: 24px;
     height: 500px; /* Increased height */
@@ -314,7 +336,7 @@ body {
 
 .output-info {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--muted-text-color);
 }
 
 .output-info p {
@@ -502,18 +524,18 @@ body {
 .controls-section h3 {
     font-weight: 600;
     margin-bottom: 8px;
-    color: #1f2937;
+    color: var(--heading-color);
 }
 
 .controls-section p {
-    color: #6b7280;
+    color: var(--muted-text-color);
     margin-bottom: 12px;
     font-size: 14px;
 }
 
 .activation-info {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--muted-text-color);
     margin-top: 8px;
 }
 
@@ -524,11 +546,11 @@ body {
 .visualization-section h3 {
     font-weight: 600;
     margin-bottom: 8px;
-    color: #1f2937;
+    color: var(--heading-color);
 }
 
 .visualization-section p {
-    color: #6b7280;
+    color: var(--muted-text-color);
     margin-bottom: 12px;
     font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- add theme toggle button to controls for dark mode
- persist user-selected theme via localStorage
- refactor styles to use CSS variables and support dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1535c12c8327a6a02f126ee57e95