### PR TITLE
Add Guided Learning Lab, concept-check quiz, and reasoning hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository contains a vanilla JavaScript interactive neural network visuali
 - Keep log entries concise and add them in reverse chronological order (newest at the top).
 
 ## Log
+ - 2026-02-08: Added a Guided Learning Lab with challenge prompts, concept-check quiz feedback, and output reasoning text to improve teaching value.
  - 2025-08-14: Simplified page text for students and added clickable glossary keyword links.
  - 2025-08-14: Corrected network visualization so connection lines pass through neuron centers.
  - 2025-08-13: Added dark mode toggle with persistent theme settings to improve UI/UX.

--- a/index.html
+++ b/index.html
@@ -104,9 +104,54 @@
             <p>The output layer shows what the network thinks. In MIM, the two numbers tell how strongly each diagonal is detected. Values near 1 mean strong matches.</p>
             <div id="outputResults" class="output-results"></div>
             <p id="predictionText" class="prediction-text"></p>
+            <p id="reasoningText" class="reasoning-text"></p>
             <div class="output-info">
                 <p>In the original MIM: Output 0 = Diagonal &#92;, Output 1 = Diagonal /</p>
                 <p>Values closer to 1.0 indicate stronger detection</p>
+            </div>
+        </div>
+
+        <!-- Guided Learning Lab -->
+        <div class="teaching-section">
+            <h3>Guided Learning Lab</h3>
+            <p>Choose a challenge, make a prediction, and then compare your thinking with the network's output.</p>
+            <div class="teaching-controls">
+                <label for="lessonSelect">Challenge:</label>
+                <select id="lessonSelect" class="select">
+                    <option value="diagonal-backslash">Detect Diagonal \</option>
+                    <option value="diagonal-slash">Detect Diagonal /</option>
+                    <option value="confusing-pattern">Spot a Confusing Pattern</option>
+                    <option value="blank-vs-full">Compare Empty and Full</option>
+                </select>
+                <button id="applyLessonBtn" class="btn btn-blue">Load Challenge Pattern</button>
+            </div>
+            <div id="lessonPrompt" class="lesson-prompt"></div>
+
+            <div class="concept-check">
+                <h4>Quick Concept Check</h4>
+                <p>Before revealing feedback, answer these checks to strengthen your intuition.</p>
+                <div class="quiz-grid">
+                    <label>
+                        Which output should be strongest?
+                        <select id="quizBestOutput" class="select">
+                            <option value="">Choose one...</option>
+                            <option value="0">Output 0 (Diagonal \)</option>
+                            <option value="1">Output 1 (Diagonal /)</option>
+                            <option value="none">Neither should be strong</option>
+                        </select>
+                    </label>
+                    <label>
+                        The top-left pixel has what influence on Output 0?
+                        <select id="quizWeightSign" class="select">
+                            <option value="">Choose one...</option>
+                            <option value="positive">Positive influence</option>
+                            <option value="negative">Negative influence</option>
+                            <option value="none">No influence</option>
+                        </select>
+                    </label>
+                </div>
+                <button id="checkQuizBtn" class="btn btn-green">Check My Answers</button>
+                <div id="quizFeedback" class="quiz-feedback"></div>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -54,6 +54,29 @@ class NeuralNetworkBuilder {
             linear: 'Linear passes values through unchanged.'
         };
 
+        this.lessonScenarios = {
+            'diagonal-backslash': {
+                pattern: [1, 0, 0, 1],
+                prompt: 'Prediction challenge: the pattern is a \\ diagonal. Which output should win, and why?',
+                expectedBestOutput: '0'
+            },
+            'diagonal-slash': {
+                pattern: [0, 1, 1, 0],
+                prompt: 'Prediction challenge: this is a / diagonal. Which neuron should activate most strongly?',
+                expectedBestOutput: '1'
+            },
+            'confusing-pattern': {
+                pattern: [0, 1, 1, 1],
+                prompt: 'Prediction challenge: this pattern is close to / but has extra pixels. Will the network stay confident?',
+                expectedBestOutput: '1'
+            },
+            'blank-vs-full': {
+                pattern: [0, 0, 0, 0],
+                prompt: 'Prediction challenge: no active pixels. Should either output fire strongly?',
+                expectedBestOutput: 'none'
+            }
+        };
+
         this.isDarkMode = localStorage.getItem('theme') === 'dark';
 
         this.init();
@@ -70,6 +93,7 @@ class NeuralNetworkBuilder {
         this.renderWeightMatrices();
         this.renderResults();
         this.updateActivationInfo();
+        this.initLessonLab();
         this.initTheme();
 
         // Initialize Lucide icons
@@ -96,6 +120,8 @@ class NeuralNetworkBuilder {
         document.getElementById('resetBtn').addEventListener('click', () => this.resetToMIM());
         document.getElementById('showMathBtn').addEventListener('click', () => this.toggleMath());
         document.getElementById('themeToggle').addEventListener('click', () => this.toggleTheme());
+        document.getElementById('applyLessonBtn').addEventListener('click', () => this.applySelectedLesson());
+        document.getElementById('checkQuizBtn').addEventListener('click', () => this.checkConceptQuiz());
 
         // Activation function selector
         document.getElementById('activationSelect').addEventListener('change', (e) => {
@@ -106,6 +132,8 @@ class NeuralNetworkBuilder {
             this.renderMathematicalBreakdown();
             this.updateActivationInfo();
         });
+
+        document.getElementById('lessonSelect').addEventListener('change', () => this.updateLessonPrompt());
         
         // Pixel grid
         document.getElementById('pixelGrid').addEventListener('click', (e) => {
@@ -568,6 +596,7 @@ class NeuralNetworkBuilder {
         });
 
         const predictionEl = document.getElementById('predictionText');
+        const reasoningEl = document.getElementById('reasoningText');
         if (predictionEl) {
             if (outputActivations.length) {
                 const maxVal = Math.max(...outputActivations);
@@ -580,6 +609,10 @@ class NeuralNetworkBuilder {
             } else {
                 predictionEl.textContent = '';
             }
+        }
+
+        if (reasoningEl) {
+            reasoningEl.textContent = this.buildReasoningText(outputActivations);
         }
     }
     
@@ -699,6 +732,81 @@ class NeuralNetworkBuilder {
             
             container.appendChild(layerDiv);
         });
+    }
+
+
+    initLessonLab() {
+        const lessonSelect = document.getElementById('lessonSelect');
+        if (!lessonSelect) return;
+        lessonSelect.value = 'diagonal-backslash';
+        this.updateLessonPrompt();
+    }
+
+    updateLessonPrompt() {
+        const lessonSelect = document.getElementById('lessonSelect');
+        const promptEl = document.getElementById('lessonPrompt');
+        if (!lessonSelect || !promptEl) return;
+
+        const scenario = this.lessonScenarios[lessonSelect.value];
+        promptEl.textContent = scenario ? scenario.prompt : '';
+    }
+
+    applySelectedLesson() {
+        const lessonSelect = document.getElementById('lessonSelect');
+        if (!lessonSelect) return;
+
+        const scenario = this.lessonScenarios[lessonSelect.value];
+        if (!scenario) return;
+
+        this.inputPattern = [...scenario.pattern];
+        this.updatePixelGrid();
+        this.calculateForwardPass(true);
+        this.renderResults();
+        this.renderMathematicalBreakdown();
+        this.updateLessonPrompt();
+    }
+
+    buildReasoningText(outputActivations) {
+        if (!outputActivations.length) return '';
+
+        const [backslashScore = 0, slashScore = 0] = outputActivations;
+        const strongerLabel = backslashScore >= slashScore ? 'Diagonal \\' : 'Diagonal /';
+        const difference = Math.abs(backslashScore - slashScore);
+
+        if (difference < 0.1) {
+            return 'Teaching note: both outputs are close, so this pattern is ambiguous for the current network settings.';
+        }
+
+        return `Teaching note: ${strongerLabel} is stronger by ${difference.toFixed(2)}, so those matching pixels and weights are dominating the decision.`;
+    }
+
+    checkConceptQuiz() {
+        const bestOutputAnswer = document.getElementById('quizBestOutput')?.value;
+        const weightSignAnswer = document.getElementById('quizWeightSign')?.value;
+        const feedbackEl = document.getElementById('quizFeedback');
+        const lessonSelect = document.getElementById('lessonSelect');
+
+        if (!feedbackEl || !lessonSelect) return;
+
+        const scenario = this.lessonScenarios[lessonSelect.value];
+        const correctBestOutput = scenario?.expectedBestOutput || 'none';
+        const correctWeightSign = 'positive';
+
+        const bestOutputCorrect = bestOutputAnswer === correctBestOutput;
+        const weightSignCorrect = weightSignAnswer === correctWeightSign;
+
+        const messages = [];
+        messages.push(bestOutputCorrect
+            ? '✅ Output prediction: correct.'
+            : `❌ Output prediction: try again. For this challenge, the best answer is ${correctBestOutput === 'none' ? 'neither output is strong' : `Output ${correctBestOutput}`}.`);
+
+        messages.push(weightSignCorrect
+            ? '✅ Weight sign: correct. In MIM, the top-left pixel supports Output 0 with a positive weight.'
+            : '❌ Weight sign: not yet. Check the first row of the weight matrix from Input to Output.');
+
+        const score = [bestOutputCorrect, weightSignCorrect].filter(Boolean).length;
+        feedbackEl.textContent = `${messages.join(' ')} Score: ${score}/2.`;
+        feedbackEl.classList.toggle('good', score === 2);
     }
 
     updateActivationInfo() {

--- a/style.css
+++ b/style.css
@@ -437,6 +437,78 @@ html {
     margin-bottom: 2px;
 }
 
+
+.reasoning-text {
+    font-size: 14px;
+    color: var(--text-color);
+    margin-bottom: 8px;
+}
+
+.teaching-section {
+    margin-bottom: 24px;
+    padding: 16px;
+    border: 1px solid #bfdbfe;
+    border-radius: 8px;
+    background-color: #eff6ff;
+}
+
+.teaching-section h3 {
+    margin-bottom: 8px;
+}
+
+.teaching-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin: 12px 0;
+}
+
+.lesson-prompt {
+    padding: 12px;
+    background-color: #ffffff;
+    border: 1px solid #dbeafe;
+    border-left: 4px solid #3b82f6;
+    border-radius: 6px;
+    margin-bottom: 16px;
+    font-size: 14px;
+}
+
+.concept-check {
+    padding: 12px;
+    background-color: #ffffff;
+    border-radius: 6px;
+    border: 1px solid #e5e7eb;
+}
+
+.concept-check h4 {
+    margin-bottom: 4px;
+}
+
+.quiz-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    margin: 12px 0;
+}
+
+.quiz-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+}
+
+.quiz-feedback {
+    margin-top: 10px;
+    font-size: 14px;
+    color: #92400e;
+}
+
+.quiz-feedback.good {
+    color: #065f46;
+}
+
 /* Glossary Section */
 .glossary-section {
     margin-top: 48px;
@@ -646,4 +718,23 @@ html {
 
 .neuron:hover {
     animation: pulse 0.5s ease-in-out;
+}
+
+body.dark .teaching-section {
+    background-color: #1e3a8a;
+    border-color: #60a5fa;
+}
+
+body.dark .lesson-prompt,
+body.dark .concept-check {
+    background-color: #111827;
+    border-color: #374151;
+}
+
+body.dark .quiz-feedback {
+    color: #fcd34d;
+}
+
+body.dark .quiz-feedback.good {
+    color: #6ee7b7;
 }


### PR DESCRIPTION
### Motivation
- Improve the educational value by giving learners small, guided experiments they can run and reason about before seeing the network's answer. 
- Provide quick formative feedback (concept checks) and a short machine-generated reasoning sentence to help build intuition about the MIM architecture.

### Description
- Add a new Guided Learning Lab UI in `index.html` with selectable challenge scenarios, a "Load Challenge Pattern" action, and a quick concept-check quiz. (`index.html`)
- Expose a short reasoning line under outputs and implement lesson logic in `script.js`, including `lessonScenarios`, `initLessonLab`, `applySelectedLesson`, `updateLessonPrompt`, `checkConceptQuiz`, and `buildReasoningText`, and wire event listeners to the new controls. (`script.js`)
- Add styles for the teaching UI (lesson prompt, quiz grid, feedback, reasoning text) and dark-mode variants to `style.css` to keep the new UI consistent with the theme. (`style.css`)
- Append a brief agent log entry describing the change to `AGENTS.md`.

### Testing
- Verified JavaScript syntax with `node --check script.js`, which completed successfully.
- Attempted automated screenshot capture using Playwright to validate the UI, but the headless browser failed to launch in this environment (Chromium crashed with a SIGSEGV and Firefox file path navigation failed), so visual verification via screenshot was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698917c573d88327b0b0565909e8a7c3)