### PR TITLE
Add Learning Coach and confidence calibration to Guided Learning Lab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository contains a vanilla JavaScript interactive neural network visuali
 - Keep log entries concise and add them in reverse chronological order (newest at the top).
 
 ## Log
+ - 2026-03-14: Added a Learning Coach panel and confidence calibration in the concept check to strengthen prediction reflection and metacognition.
  - 2026-02-08: Added a Guided Learning Lab with challenge prompts, concept-check quiz feedback, and output reasoning text to improve teaching value.
  - 2025-08-14: Simplified page text for students and added clickable glossary keyword links.
  - 2025-08-14: Corrected network visualization so connection lines pass through neuron centers.

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
             <div id="outputResults" class="output-results"></div>
             <p id="predictionText" class="prediction-text"></p>
             <p id="reasoningText" class="reasoning-text"></p>
+            <div id="learningCoach" class="learning-coach"></div>
             <div class="output-info">
                 <p>In the original MIM: Output 0 = Diagonal &#92;, Output 1 = Diagonal /</p>
                 <p>Values closer to 1.0 indicate stronger detection</p>
@@ -130,6 +131,9 @@
             <div class="concept-check">
                 <h4>Quick Concept Check</h4>
                 <p>Before revealing feedback, answer these checks to strengthen your intuition.</p>
+                <label for="confidenceRange" class="confidence-label">How confident are you in your prediction? <span id="confidenceValue">50%</span></label>
+                <input type="range" id="confidenceRange" min="0" max="100" value="50" aria-describedby="confidenceHelp">
+                <p id="confidenceHelp" class="confidence-help">Being honest about confidence helps you build strong learning habits.</p>
                 <div class="quiz-grid">
                     <label>
                         Which output should be strongest?

--- a/script.js
+++ b/script.js
@@ -44,6 +44,7 @@ class NeuralNetworkBuilder {
         // UI state
         this.activationFunction = 'sigmoid';
         this.showCalculations = false;
+        this.lastLessonResult = null;
 
         // Educational labels and descriptions
         this.outputLabels = ['Diagonal \\', 'Diagonal /'];
@@ -134,6 +135,11 @@ class NeuralNetworkBuilder {
         });
 
         document.getElementById('lessonSelect').addEventListener('change', () => this.updateLessonPrompt());
+
+        document.getElementById('confidenceRange')?.addEventListener('input', (e) => {
+            const valueEl = document.getElementById('confidenceValue');
+            if (valueEl) valueEl.textContent = `${e.target.value}%`;
+        });
         
         // Pixel grid
         document.getElementById('pixelGrid').addEventListener('click', (e) => {
@@ -614,6 +620,8 @@ class NeuralNetworkBuilder {
         if (reasoningEl) {
             reasoningEl.textContent = this.buildReasoningText(outputActivations);
         }
+
+        this.renderLearningCoach(outputActivations);
     }
     
     /**
@@ -780,9 +788,55 @@ class NeuralNetworkBuilder {
         return `Teaching note: ${strongerLabel} is stronger by ${difference.toFixed(2)}, so those matching pixels and weights are dominating the decision.`;
     }
 
+
+    renderLearningCoach(outputActivations) {
+        const coachEl = document.getElementById('learningCoach');
+        if (!coachEl) return;
+
+        if (!outputActivations.length) {
+            coachEl.textContent = '';
+            return;
+        }
+
+        const [backslashScore = 0, slashScore = 0] = outputActivations;
+        const winner = backslashScore >= slashScore ? '0' : '1';
+        const spread = Math.abs(backslashScore - slashScore);
+        const certainty = spread >= 0.35 ? 'high' : spread >= 0.15 ? 'medium' : 'low';
+
+        const certaintyText = {
+            high: 'The network is making a clear choice.',
+            medium: 'The network has a preference, but not by a huge margin.',
+            low: 'The network sees this as an ambiguous pattern.'
+        };
+
+        let lessonFeedback = '';
+        if (this.lastLessonResult) {
+            const confidenceDelta = Math.abs(this.lastLessonResult.confidence - this.lastLessonResult.networkConfidence);
+            const confidenceMessage = confidenceDelta <= 20
+                ? 'Nice calibration: your confidence matched the model fairly well.'
+                : 'Try calibrating your confidence next time by checking how separated the two outputs are.';
+
+            lessonFeedback = ` You predicted Output ${this.lastLessonResult.predictedOutput}, while the network favored Output ${winner}. ${confidenceMessage}`;
+        }
+
+        coachEl.textContent = `Learning Coach: Output ${winner} currently leads. ${certaintyText[certainty]} Compare both output values and explain what changed in the input to cause that gap.${lessonFeedback}`;
+    }
+
+    summarizePattern(pattern) {
+        const labels = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+        const active = pattern
+            .map((value, index) => value === 1 ? labels[index] : null)
+            .filter(Boolean);
+
+        if (!active.length) return 'no active pixels';
+        if (active.length === 4) return 'all pixels active';
+        return `${active.join(', ')} active`;
+    }
+
     checkConceptQuiz() {
         const bestOutputAnswer = document.getElementById('quizBestOutput')?.value;
         const weightSignAnswer = document.getElementById('quizWeightSign')?.value;
+        const confidenceValue = Number(document.getElementById('confidenceRange')?.value || 50);
         const feedbackEl = document.getElementById('quizFeedback');
         const lessonSelect = document.getElementById('lessonSelect');
 
@@ -791,6 +845,10 @@ class NeuralNetworkBuilder {
         const scenario = this.lessonScenarios[lessonSelect.value];
         const correctBestOutput = scenario?.expectedBestOutput || 'none';
         const correctWeightSign = 'positive';
+
+        const outputActivations = this.activations[`${this.layers.length - 1}`] || [];
+        const maxVal = outputActivations.length ? Math.max(...outputActivations) : 0;
+        const maxIndex = outputActivations.length ? outputActivations.indexOf(maxVal) : -1;
 
         const bestOutputCorrect = bestOutputAnswer === correctBestOutput;
         const weightSignCorrect = weightSignAnswer === correctWeightSign;
@@ -805,8 +863,21 @@ class NeuralNetworkBuilder {
             : '❌ Weight sign: not yet. Check the first row of the weight matrix from Input to Output.');
 
         const score = [bestOutputCorrect, weightSignCorrect].filter(Boolean).length;
+
+        this.lastLessonResult = {
+            predictedOutput: bestOutputAnswer || 'none',
+            confidence: confidenceValue,
+            networkConfidence: Math.round((maxVal || 0) * 100),
+            actualOutput: maxIndex >= 0 ? String(maxIndex) : 'none',
+            patternSummary: this.summarizePattern(this.inputPattern)
+        };
+
+        messages.push(`🧠 Confidence check: you reported ${confidenceValue}% confidence while the top output is ${(maxVal * 100).toFixed(0)}%.`);
+
         feedbackEl.textContent = `${messages.join(' ')} Score: ${score}/2.`;
         feedbackEl.classList.toggle('good', score === 2);
+
+        this.renderLearningCoach(outputActivations);
     }
 
     updateActivationInfo() {

--- a/style.css
+++ b/style.css
@@ -738,3 +738,37 @@ body.dark .quiz-feedback {
 body.dark .quiz-feedback.good {
     color: #6ee7b7;
 }
+
+
+.learning-coach {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-left: 4px solid #3b82f6;
+    background: #eff6ff;
+    color: #1e3a8a;
+    border-radius: 6px;
+    font-size: 14px;
+}
+
+.confidence-label {
+    display: block;
+    margin: 12px 0 4px;
+    font-weight: 600;
+}
+
+#confidenceRange {
+    width: 100%;
+    margin-bottom: 6px;
+}
+
+.confidence-help {
+    font-size: 13px;
+    color: var(--muted-text-color);
+    margin-bottom: 10px;
+}
+
+body.dark .learning-coach {
+    background: #1e3a8a;
+    color: #dbeafe;
+    border-left-color: #60a5fa;
+}


### PR DESCRIPTION
### Motivation
- Improve the educational value by helping learners reflect on both their predictions and their confidence (metacognition), not just correctness. 
- Make feedback more actionable by surfacing model certainty and comparing it to the student’s reported confidence. 

### Description
- Added a Learning Coach panel to the Network Output area and a confidence slider to the Guided Learning Lab in `index.html` to prompt confidence-aware reflection. 
- Extended app state and UI wiring in `script.js` by introducing `lastLessonResult`, a live `confidenceRange` input listener, and calling `renderLearningCoach(outputActivations)` from `renderResults`. 
- Implemented `renderLearningCoach(outputActivations)` and `summarizePattern(pattern)` in `script.js`, and enhanced `checkConceptQuiz()` to record the learner’s confidence, compute basic calibration against model output, persist the last attempt, and include that information in feedback. 
- Added styles for the coach and confidence controls (light and dark themes) to `style.css`, and appended a short log entry in `AGENTS.md` documenting the change. 

### Testing
- Static check: ran `node --check script.js` which completed successfully. 
- Manual UI validation: served the site with `python -m http.server 8000` and inspected the updated Guided Learning Lab and Learning Coach in a browser. 
- Automated UI snapshot: captured a Playwright screenshot of `http://127.0.0.1:8000/index.html` to verify the rendered UI (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b587a401488327aca55b8b290e70bf)